### PR TITLE
Add NVIDIA NemoClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Community-curated and independent. Not an official OpenClaw project unless expli
 - [OpenClaw ACP CLI](https://docs.openclaw.ai/cli/acp) - Documentation for connecting OpenClaw to ACP-compatible clients.
 
 ## Deployment and Hosting
+- [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw) - Run OpenClaw more securely inside NVIDIA OpenShell with managed inference.
 
 - [Arjun Komath OpenClaw Railway Template](https://github.com/arjunkomath/openclaw-railway-template) - One-click Railway deployment template for OpenClaw.
 - [CodeTitlan OpenClaw Railway Template](https://github.com/codetitlan/openclaw-railway-template) - Railway template for deploying OpenClaw infrastructure.


### PR DESCRIPTION
Adding [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw) to the list. Run OpenClaw more securely inside NVIDIA OpenShell with managed inference.