### PR TITLE
Add TweetClaw OpenClaw plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Community-curated and independent. Not an official OpenClaw project unless expli
 - [Ollama OpenClaw Integration](https://docs.ollama.com/integrations/openclaw) - Ollama documentation for launching OpenClaw with local model support.
 - [AI/ML API OpenClaw Quickstart](https://docs.aimlapi.com/quickstart/openclaw) - Provider quickstart for configuring OpenClaw with AI/ML API models.
 - [OpenClaw Lark/Feishu Plugin](https://github.com/larksuite/openclaw-lark) - Official Lark/Feishu Open Platform plugin for connecting OpenClaw to messages, docs, bases, sheets, calendars, and tasks.
+- [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - OpenClaw plugin for search tweets, search tweet replies, post tweets, post tweet replies, export followers, monitor accounts, and run giveaway draws through structured Xquik endpoints.
 
 ## Coding Agents and ACP
 


### PR DESCRIPTION
Disclosure: I maintain TweetClaw and Xquik.

## Summary
- add TweetClaw to the Plugins and Integrations section
- describe concrete OpenClaw jobs it enables: search tweets, search tweet replies, post tweets, post tweet replies, follower export, monitoring, and giveaway draws
- keep the existing directory style and link directly to the canonical GitHub repository

## Validation
- read README, CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE, and SECURITY.md
- checked open and closed PRs and issues for TweetClaw and Xquik duplicates
- ran `git diff --check`

Link: https://github.com/Xquik-dev/tweetclaw
