### PR TITLE
Add ClawLens to Plugins and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Community-curated and independent. Not an official OpenClaw project unless expli
 - [Ollama OpenClaw Integration](https://docs.ollama.com/integrations/openclaw) - Ollama documentation for launching OpenClaw with local model support.
 - [AI/ML API OpenClaw Quickstart](https://docs.aimlapi.com/quickstart/openclaw) - Provider quickstart for configuring OpenClaw with AI/ML API models.
 - [OpenClaw Lark/Feishu Plugin](https://github.com/larksuite/openclaw-lark) - Official Lark/Feishu Open Platform plugin for connecting OpenClaw to messages, docs, bases, sheets, calendars, and tasks.
+- [ClawLens](https://github.com/nk3750/clawlens) - Local-first OpenClaw plugin for agent observability, hash-chain audit trails, risk scoring, and block/approval/notify guardrails.
 
 ## Coding Agents and ACP
 


### PR DESCRIPTION
Adds **ClawLens** to the `## Plugins and Integrations` section.

**ClawLens** is a local-first OpenClaw plugin for agent observability and runtime guardrails. It sits inside the OpenClaw runtime, observes every tool call before execution, scores risky behavior, keeps a tamper-evident hash-chain audit trail, and lets operators turn observed actions into block / require-approval / allow-notify guardrails delivered to Telegram.

**Install**
```
openclaw plugins install clawhub:@nk3750/openclaw-clawlens
```

**Links**
- GitHub: https://github.com/nk3750/clawlens
- ClawHub (v1.0.1, MIT, ClawScan-passed): https://clawhub.ai/plugins/@nk3750/openclaw-clawlens
- 2-min demo: https://youtu.be/AKzhw5GWw5I

Happy to reformat or move sections if needed.